### PR TITLE
Added missing dependency (pcl_ros)

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -6,6 +6,8 @@
   <maintainer email="tomoya.sato@tier4.jp">Tomoya-Sato</maintainer>
   <license>TODO</license>
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>pcl_ros</build_depend>
+  <run_depend>pcl_ros</run_depend>
   <export>
   </export>
 </package>


### PR DESCRIPTION
# Description

The current package depends on PCL. However, the `package.xml` doesn't contain the `pcl_ros` package. As a result, on a clean system (or Docker build), PCL will not be installed properly via `rosdep install`.